### PR TITLE
Travis doesn't cleanup before publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       script: npm pack
     - stage: npm release
       node_js: "8"
-      script: echo "Deploying to npm ..."
+      script: npm install
       deploy:
         provider: npm
         email: opensource@internap.com


### PR DESCRIPTION
The npm pack step needs access to the node_modules to be able to deploy,
this make sure that node_modules will still be there.