### PR TITLE
Consider arrays as values

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,7 @@
   "indent": 2,
   "undef": true,
   "quotmark": "single",
-  "maxlen": 80,
+  "maxlen": 120,
   "trailing": true,
   "curly": true,
   "globals"   : {

--- a/jabstract.js
+++ b/jabstract.js
@@ -1,31 +1,32 @@
 /*jshint node:true */
 'use strict';
 
-module.exports = function jabstract(payload) {
-  return (target) => _merge(target, payload);
+module.exports = function(payload) {
+  return (target) => merge(target, payload);
 };
 
-function _merge(target, payload = []) {
+function merge(target, payload) {
   if (typeof target === 'undefined') {
-    return payload;
+    target = {};
   }
 
-  let newPayload = Object.assign({}, payload);
+  const newPayload = deepCopy(payload);
+
   Object.keys(target).forEach(k => {
-    if (_isObject(target[k])) {
-      if (k in payload) {
-        newPayload[k] = _merge(target[k], newPayload[k]);
-      } else {
-        Object.assign(newPayload, { [k]: target[k] });
-      }
+    if (isDict(target[k]) && k in payload) {
+      newPayload[k] = merge(target[k], newPayload[k]);
     } else {
-      Object.assign(newPayload, { [k]: target[k] });
+      newPayload[k] = target[k];
     }
   });
 
   return newPayload;
 }
 
-function _isObject(o) {
-    return o !== null && typeof o === 'object';
+function deepCopy(payload) {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+function isDict(o) {
+    return o !== null && typeof o === 'object'  && !Array.isArray(o);
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepack": "./node_modules/browserify/bin/cmd.js jabstract.js -o dist/jabstract-browser-es5.js --s jabstract -t [ babelify --presets [ env ] --plugins [ transform-object-assign ] ]",
     "jshint": "./node_modules/jshint/bin/jshint . --exclude node_modules"
   },
-  "files":[
+  "files": [
     "jabstract.js",
     "package.json",
     "dist",


### PR DESCRIPTION
When customizing a payload, anyway array should be overridden because
one might want to have an empty array, or one different from the one in
the payload.  Having to manually removes items after the generation is
not going to look pretty.

Bonus: Made the tests more bdd-ish and made sure the original payload
was not modifiable