### PR TITLE
Support null in fixtures

### DIFF
--- a/jabstract.js
+++ b/jabstract.js
@@ -13,7 +13,7 @@ function merge(target, payload) {
   const newPayload = deepCopy(payload);
 
   Object.keys(target).forEach(k => {
-    if (isDict(target[k]) && k in payload) {
+    if (isDict(target[k]) && isDict(newPayload[k])) {
       newPayload[k] = merge(target[k], newPayload[k]);
     } else {
       newPayload[k] = target[k];

--- a/test/test_jabstract.js
+++ b/test/test_jabstract.js
@@ -125,4 +125,22 @@ describe('jabstract', () => {
 
     assert.deepEqual(response.client.hobbies, ['stubbing']);
   });
+
+  it(`should allow null dicts in the fixtures`, () => {
+    let apiResponse = jabstract({
+      'client': {
+        'stuff': null
+      }
+    });
+
+    let response = apiResponse({
+      'client': {
+        'stuff': {
+          'car': 'tesla model 3'
+        }
+      }
+    });
+
+    assert.deepEqual(response.client.stuff.car, 'tesla model 3');
+  });
 });


### PR DESCRIPTION
Having a null value where a dictionary is to be inserted was generating
an error trying to merge a dict with a null.